### PR TITLE
Include head ref info to Check Request event payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "orgu"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orgu"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/checkout.rs
+++ b/src/checkout.rs
@@ -97,6 +97,7 @@ impl Checkout for Libgit2Checkout {
         )
     )]
     async fn checkout_under(&self, input: &CheckoutInput, under: &Path) -> Result<()> {
+        // If no_fetch is enabled, skip fetching and just set remote in fetch_with_timeout().
         let repo =
             fetch_with_timeout(under.to_path_buf(), input.clone(), self.config.clone()).await?;
 

--- a/src/cli/pattern/test.rs
+++ b/src/cli/pattern/test.rs
@@ -145,6 +145,7 @@ fn example_check_request(args: TestArgs, custom_props: HashMap<String, String>) 
         before: None,
         after: Some("a8619f1cf1f6ade02df413b18265f74d3bc9caca".to_owned()),
         pull_request_number: pr_number,
+        pull_request_head_ref: Some("feature".to_owned()),
         sender: User { login: args.sender },
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -27,6 +27,8 @@ pub struct CheckRequest {
     /// Pull request number if the event is associated with a pull request. check_suite events can be associated with
     /// multiple PRs and if so, this will be the first PR number.
     pub pull_request_number: Option<u64>,
+    /// Reference name of the head. Always available for pull_request events.
+    pub pull_request_head_ref: Option<String>,
     /// User who triggered the event.
     pub sender: User,
 }

--- a/src/front/github_events.rs
+++ b/src/front/github_events.rs
@@ -57,6 +57,11 @@ impl CheckSuiteEvent {
             // for specific PR may not be possible. This is rare case and pushing empty commit will be work-around for
             // that case.
             pull_request_number: self.check_suite.pull_requests.first().map(|pr| pr.number),
+            pull_request_head_ref: self
+                .check_suite
+                .pull_requests
+                .first()
+                .map(|pr| pr.head.ref_.clone()),
             sender: self.common.sender,
         }
     }
@@ -112,6 +117,7 @@ impl PullRequestEvent {
             before,
             after,
             pull_request_number: Some(self.number),
+            pull_request_head_ref: Some(self.pull_request.head.ref_.clone()),
             sender: self.common.sender,
         }
     }
@@ -133,6 +139,7 @@ pub struct CheckSuite {
 pub struct CheckSuitePullRequest {
     pub id: u64,
     pub number: u64,
+    pub head: Reference,
 }
 
 // https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request

--- a/src/runner/cli/oneshot.rs
+++ b/src/runner/cli/oneshot.rs
@@ -66,6 +66,7 @@ pub async fn oneshot(global: GlobalArgs, args: OneshotArgs) -> CommandResult {
         before: None,
         after: Some(head_sha.clone()),
         pull_request_number: None,
+        pull_request_head_ref: None,
         repository: repo,
         sender: User {
             login: "octocat".to_owned(),

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -213,6 +213,10 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
             .env("CI_EVENT_NAME", req.event_name.clone())
             .env("CI_EVENT_ACTION", req.action.clone())
             .env("CI_HEAD", req.head_sha.clone())
+            .env(
+                "CI_HEAD_REF",
+                req.pull_request_head_ref.clone().unwrap_or_default(),
+            )
             .env("CI_BASE", req.base_sha.clone().unwrap_or_default())
             .env("CI_BASE_REF", req.base_ref.clone().unwrap_or_default())
             .env("CI_BEFORE", req.before.clone().unwrap_or_default())
@@ -315,6 +319,7 @@ mod tests {
             action: "synchronize".to_owned(),
             head_sha: "testsha".to_owned(),
             pull_request_number: Some(55),
+            pull_request_head_ref: Some("test-branch".to_owned()),
             repository: GithubRepository {
                 full_name: "owner/repo".to_owned(),
                 name: "repo".to_owned(),
@@ -373,6 +378,7 @@ mod tests {
                 .summary
                 .starts_with("Command succeeded"));
             let text = &input.output.as_ref().unwrap().text;
+
             assert!(text.contains("GITHUB_TOKEN=test_token"));
 
             assert!(text.contains("REVIEWDOG_GITHUB_API_TOKEN=test_token"));
@@ -382,6 +388,9 @@ mod tests {
             assert!(text.contains("CI_REPO_OWNER=owner"));
             assert!(text.contains("CI_REPO_NAME=repo"));
             assert!(text.contains("CI_PULL_REQUEST=55"));
+
+            assert!(text.contains("CI_HEAD=testsha"));
+            assert!(text.contains("CI_HEAD_REF=test-branch"));
 
             assert!(text.contains("PATH="));
 


### PR DESCRIPTION
In case that CI jobs commit and push to PRs, they need head ref.