### PR TITLE
Use latest cargo in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c # Latest
+        with:
+          toolchain: stable
       - name: Extract crate information
         id: crate-metadata
         shell: bash


### PR DESCRIPTION
https://github.com/Finatext/orgu/actions/runs/13513289119/job/37757415948

>error: failed to parse manifest at `/home/runner/work/orgu/orgu/Cargo.toml`

>Caused by:
  feature `edition2024` is required

>  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-[19](https://github.com/Finatext/orgu/actions/runs/13513289119/job/37757415948#step:3:20))).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-[20](https://github.com/Finatext/orgu/actions/runs/13513289119/job/37757415948#step:3:21)24 for more information about the status of this feature.