### PR TITLE
Disable missing-const-for-fn lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,4 @@ wildcard_enum_match_arm = "warn"
 # Enable all nursery lints.
 nursery = { level = "warn", priority = -1 }
 future_not_send = "allow"
+missing-const-for-fn = "allow"


### PR DESCRIPTION
Due to its false-postitiveness.