### PR TITLE
Allow setting custom env vars to jobs

### DIFF
--- a/src/github_verifier.rs
+++ b/src/github_verifier.rs
@@ -47,12 +47,4 @@ pub mod test {
             Ok(())
         }
     }
-
-    pub struct FailVerifier;
-
-    impl GithubRequestVerifier for FailVerifier {
-        fn verify_request(_headers: &HeaderMap, _body: &str, _secret: &str) -> Result<()> {
-            bail!("always failed")
-        }
-    }
 }

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -222,8 +222,6 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
         let mut c = Command::new(program);
         // Default to pipe stdin etc. Not to be piped, use `wait_with_output` instead of `output`.
         // https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.output
-        //
-        // Add reviewdog env vars: https://github.com/reviewdog/reviewdog?tab=readme-ov-file#jenkins-with-github-pull-request-builder-plugin
         c.args(args).current_dir(work_dir).env_clear();
 
         for entry in job_env.iter() {

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -222,7 +222,9 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
         let mut c = Command::new(program);
         // Default to pipe stdin etc. Not to be piped, use `wait_with_output` instead of `output`.
         // https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.output
-        c.args(args).current_dir(work_dir).env_clear();
+        //
+        // Default to inherit environment variables.
+        c.args(args).current_dir(work_dir);
 
         for entry in job_env.iter() {
             c.env(&entry.key, &entry.value);

--- a/src/runner/hanlder_view.rs
+++ b/src/runner/hanlder_view.rs
@@ -160,7 +160,7 @@ impl UpdateInputBase {
         match &self.job_env {
             None => outs,
             Some(e) => {
-                format!("## env\n```\n{}\n```\n{}", job_env_text(e), outs)
+                format!("## job env\n```\n{}\n```\n{}", job_env_text(e), outs)
             }
         }
     }

--- a/src/runner/job_env.rs
+++ b/src/runner/job_env.rs
@@ -14,7 +14,7 @@ pub struct Entry {
 pub fn build_job_env(req: &CheckRequest, token: &str, job_name: &str) -> JobEnv {
     let mut vars = vec![
         env("GITHUB_TOKEN", token, true),
-        // Reviewdog env vars.
+        // Reviewdog env vars. https://github.com/reviewdog/reviewdog?tab=readme-ov-file#jenkins-with-github-pull-request-builder-plugin
         env("REVIEWDOG_GITHUB_API_TOKEN", token, true),
         env("REVIEWDOG_SKIP_DOGHOUSE", "true", false),
         env("JOB_NAME", job_name, false),

--- a/src/runner/job_env.rs
+++ b/src/runner/job_env.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsStr};
+use std::ffi::OsStr;
 
 use crate::events::CheckRequest;
 
@@ -48,10 +48,6 @@ pub fn build_job_env(req: &CheckRequest, token: &str, job_name: &str) -> JobEnv 
         env("CI_BEFORE", req.before.clone().unwrap_or_default(), false),
         env("CI_AFTER", req.after.clone().unwrap_or_default(), false),
     ];
-
-    if let Ok(v) = env::var("PATH") {
-        vars.push(env("PATH", v, false));
-    }
 
     // Job can refer custom properties as env vars with `CUSTOM_PROP_` prefix with upcased key.
     // e.g. `CUSTOM_PROP_TEAM=t-ferris`.


### PR DESCRIPTION
Inherit environment variables from runner to job.

Previously, orgu used env_clear() to provide only explicitly defined
environment variables to jobs, following a "secure by default" policy
where unnecessary features are avoided for robustness. However, as use
cases have emerged where jobs need various environment variables
configured in the runner environment, we now inherit all environment
variables by default instead of clearing them.

This allows users to pass custom configuration through environment
variables without modifying the orgu codebase.