### PR TITLE
Explicitly cleanup temp dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -2165,6 +2165,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2347,7 @@ dependencies = [
  "lambda_http",
  "lambda_runtime",
  "mockall",
+ "nix",
  "octorust",
  "pem",
  "pretty_assertions",
@@ -2872,7 +2885,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ retry-policies = "0"
 serde = "1.0.228"
 serde_json = "1.0.145"
 sha2 = "0.10.9"
+nix = { version = "0.30", features = ["fs"] }
 strum = { version = "0.27", features = ["derive"] }
 subtle = "2.6.1"
 tempfile = "3.23.0"

--- a/src/checkout.rs
+++ b/src/checkout.rs
@@ -63,6 +63,18 @@ pub struct WorkDir {
     pub _parent: tempfile::TempDir,
 }
 
+impl WorkDir {
+    /// Explicitly cleanup the temporary directory.
+    pub fn cleanup(self) -> Result<()> {
+        self._parent.close().with_context(|| {
+            format!(
+                "failed to cleanup temporary directory: {}",
+                self.path.display()
+            )
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct Libgit2Checkout {
     config: CheckoutConfig,

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -312,9 +312,15 @@ async fn log_disk_usage(label: &str) {
     let tmp_dir = temp_dir();
     match statvfs(&tmp_dir) {
         Ok(stat) => {
-            #[allow(clippy::useless_conversion, reason = "c_ulong is u64 on macOS but u32 on some Linux platforms")]
+            #[allow(
+                clippy::useless_conversion,
+                reason = "c_ulong is u64 on macOS but u32 on some Linux platforms"
+            )]
             let total = u64::from(stat.blocks()) * stat.fragment_size();
-            #[allow(clippy::useless_conversion, reason = "c_ulong is u64 on macOS but u32 on some Linux platforms")]
+            #[allow(
+                clippy::useless_conversion,
+                reason = "c_ulong is u64 on macOS but u32 on some Linux platforms"
+            )]
             let available = u64::from(stat.blocks_available()) * stat.fragment_size();
             let used = total - available;
 

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -312,7 +312,9 @@ async fn log_disk_usage(label: &str) {
     let tmp_dir = temp_dir();
     match statvfs(&tmp_dir) {
         Ok(stat) => {
+            #[allow(clippy::useless_conversion, reason = "c_ulong is u64 on macOS but u32 on some Linux platforms")]
             let total = u64::from(stat.blocks()) * stat.fragment_size();
+            #[allow(clippy::useless_conversion, reason = "c_ulong is u64 on macOS but u32 on some Linux platforms")]
             let available = u64::from(stat.blocks_available()) * stat.fragment_size();
             let used = total - available;
 

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -1,12 +1,17 @@
-use std::{future::Future, path::Path};
+use std::{
+    env::{temp_dir, var},
+    future::Future,
+    path::Path,
+};
 
 use anyhow::{Context as _, Result};
 use clap::Args;
+use nix::sys::statvfs::statvfs;
 use tokio::{
     process::Command,
     time::{Instant, timeout},
 };
-use tracing::{Instrument, error, info, info_span, instrument, trace};
+use tracing::{Instrument, error, info, info_span, instrument, trace, warn};
 
 use crate::{
     checkout::{Checkout, CheckoutError, CheckoutInput},
@@ -113,6 +118,8 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
         let mut update_input =
             create_input.into_update_input(check_run.id, self.config.wrap_stdout);
 
+        log_disk_usage("before job execution").await;
+
         self.ensure_updating_check_run(update_input.clone(), async move {
             let owner = &req.repository.owner.login;
             let repo = &req.repository.name;
@@ -148,13 +155,16 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
 
             let job_env = build_job_env(&req, &token, &self.config.job_name);
             update_input.job_env = Some(job_env.clone());
+
             let cmd = self.build_command(&cloned.path, &job_env)?;
             let span =
                 info_span!("run command", command = fmt_cmd(&cmd), path = %cloned.path.display());
             let result = self.run_command(cmd, update_input).instrument(span).await;
 
+            log_disk_usage("after job execution").await;
             // Explicitly cleanup before returning to ensure it happens before Lambda freeze.
             cloned.cleanup()?;
+            log_disk_usage("after cleanup").await;
 
             result
         })
@@ -259,6 +269,62 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
                 // After successfully updating the check run, return the original error.
                 Err(e)
             }
+        }
+    }
+}
+
+// Format bytes to human-readable string (e.g., "1.5 TB", "512 GB").
+#[allow(
+    clippy::as_conversions,
+    reason = "u64 to f64 conversion is safe for display purposes, precision loss is acceptable"
+)]
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.2} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+// Log disk usage of tmp filesystem using statvfs.
+// Only runs when ORGU_LOG_DISK_USAGE environment variable is set.
+async fn log_disk_usage(label: &str) {
+    if var("ORGU_LOG_DISK_USAGE").is_err() {
+        return;
+    }
+
+    let tmp_dir = temp_dir();
+    match statvfs(&tmp_dir) {
+        Ok(stat) => {
+            let total = u64::from(stat.blocks()) * stat.fragment_size();
+            let available = u64::from(stat.blocks_available()) * stat.fragment_size();
+            let used = total - available;
+
+            info!(
+                label = label,
+                tmp_dir = %tmp_dir.display(),
+                total_bytes = total,
+                used_bytes = used,
+                available_bytes = available,
+                total = format_bytes(total),
+                used = format_bytes(used),
+                available = format_bytes(available),
+                "tmp filesystem disk usage"
+            );
+        }
+        Err(e) => {
+            warn!(label = label, tmp_dir = %tmp_dir.display(), error = %e, "failed to get filesystem stats");
         }
     }
 }

--- a/src/runner/handler.rs
+++ b/src/runner/handler.rs
@@ -163,7 +163,12 @@ impl<CL: GithubClient, CH: Checkout, F: TokenFetcher> Handler<CL, CH, F> {
 
             log_disk_usage("after job execution").await;
             // Explicitly cleanup before returning to ensure it happens before Lambda freeze.
-            cloned.cleanup()?;
+            // Temporary: Can skip cleanup with ORGU_NO_EXPLICITLY_CLEANUP env var to observe disk usage behavior.
+            if var("ORGU_NO_EXPLICITLY_CLEANUP").is_ok() {
+                info!("skipping explicit cleanup (NO_EXPLICITLY_CLEANUP is set)");
+            } else {
+                cloned.cleanup()?;
+            }
             log_disk_usage("after cleanup").await;
 
             result


### PR DESCRIPTION
Explicitly cleanup before returning to ensure it happens before Lambda freeze.

And adds temporary flags and logging to observe disk usages.

Some jobs occasionally fail with "Resource temporarily unavailable (os error 11)" errors. This flag allows us to observe disk usage behavior and investigate whether the explicit cleanup is related to these failures.